### PR TITLE
Move flink-jdbc_2.11 to baseline

### DIFF
--- a/flink-baseline/flink-jdbc-sink/pom.xml
+++ b/flink-baseline/flink-jdbc-sink/pom.xml
@@ -17,11 +17,6 @@
             <artifactId>flink-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <!-- Switch to ${scala.binary.version} when version becomes available -->
-            <artifactId>flink-jdbc_2.11</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+             <groupId>org.apache.flink</groupId>
+             <!-- Switch to ${scala.binary.version} when version becomes available -->
+             <artifactId>flink-jdbc_2.11</artifactId>
+         </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Fixed issue
```
[WARNING] The POM for com.riskfocus.flink.generic:flink-jdbc-sink:jar:1.0-master-20200519.150316-1 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model for com.riskfocus.flink.generic:flink-jdbc-sink:1.0-master-SNAPSHOT
[ERROR] 'dependencies.dependency.version' for org.apache.flink:flink-jdbc_2.11:jar is missing. @ 

```