### PR TITLE
MAX_PARTITION_FETCH_BYTES_CONFIG & FETCH_MAX_BYTES_CONFIG

### DIFF
--- a/flink-baseline/flink-common/src/main/java/com/riskfocus/flink/config/kafka/KafkaProperties.java
+++ b/flink-baseline/flink-common/src/main/java/com/riskfocus/flink/config/kafka/KafkaProperties.java
@@ -77,6 +77,9 @@ public class KafkaProperties {
         consumerProps.setProperty(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, fetchMaxWaitMs);
         consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
 
+        consumerProps.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, params.getString(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "1048576"));
+        consumerProps.setProperty(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, params.getString(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, "57671680"));
+
         consumerProps.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
         consumerProps.setProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, autoCommitIntervalMs);
 


### PR DESCRIPTION
Added possibility to configure MAX_PARTITION_FETCH_BYTES_CONFIG & FETCH_MAX_BYTES_CONFIG parameters for Kafka Consumer

See https://kafka.apache.org/documentation/