### PR TITLE
Added possibility to configure network buffers

### DIFF
--- a/flink-baseline/flink-common/src/main/java/com/riskfocus/flink/config/kafka/KafkaProperties.java
+++ b/flink-baseline/flink-common/src/main/java/com/riskfocus/flink/config/kafka/KafkaProperties.java
@@ -77,6 +77,9 @@ public class KafkaProperties {
         consumerProps.setProperty(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, fetchMaxWaitMs);
         consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
 
+        consumerProps.setProperty(ConsumerConfig.SEND_BUFFER_CONFIG, params.getString(ConsumerConfig.SEND_BUFFER_CONFIG, "131072"));
+        consumerProps.setProperty(ConsumerConfig.RECEIVE_BUFFER_CONFIG, params.getString(ConsumerConfig.RECEIVE_BUFFER_CONFIG, "65536"));
+
         consumerProps.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, params.getString(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "1048576"));
         consumerProps.setProperty(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, params.getString(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, "57671680"));
 


### PR DESCRIPTION
Added possibility to configure network buffers SEND_BUFFER_CONFIG & RECEIVE_BUFFER_CONFIG parameters for Kafka Consumer

See details: https://blog.newrelic.com/engineering/kafka-best-practices/#consumers