### PR TITLE
RFAC-91: Added possibility to get secrets from AWS SM

### DIFF
--- a/flink-baseline/flink-common/pom.xml
+++ b/flink-baseline/flink-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/aws/SecretsRetrieval.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/aws/SecretsRetrieval.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.config.aws;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.ness.flink.config.properties.AwsProperties;
+import com.ness.flink.config.properties.RawProperties;
+import com.ness.flink.security.Credentials;
+import com.ness.flink.json.UncheckedObjectMapper;
+import com.ness.flink.security.SecretsAware;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Retrieve secrets from AWS Secret manager
+ * @author Khokhlov Pavel
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Internal
+public class SecretsRetrieval implements SecretsAware {
+
+    private final SecretCache cache;
+
+    /**
+     * Provides secret by secret name, secret should be in JSON format: {"login":"login1","password":"password1"}
+     * 
+     * @param secretName name of secret
+     * @return LoginPassword information
+     */
+    @Override
+    public Credentials retrieve(String secretName) {
+        String secret = getSecret(secretName);
+        return UncheckedObjectMapper.MAPPER.readValue(secret, Credentials.class);
+    }
+
+    /**
+     * Provides secret by secret name
+     * @param secretName name of secret
+     * @return secret value
+     */
+    private String getSecret(String secretName) {
+        return cache.getSecretString(secretName);
+    }
+
+    /**
+     * Builds SecretsRetrieval
+     * @param secretProviderProperties AWS Settings
+     * @return SecretsRetrieval
+     */
+    public static SecretsRetrieval build(RawProperties<?> secretProviderProperties) {
+        AWSSecretsManagerClientBuilder standard = AWSSecretsManagerClientBuilder.standard();
+        String region = secretProviderProperties.getRawValues().get(AwsProperties.AWS_REGION);
+        if (region != null) {
+            standard.setRegion(region);
+        }
+        SecretCache secretCache = new SecretCache(standard);
+        return new SecretsRetrieval(secretCache);
+    }
+}

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaAwareSink.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaAwareSink.java
@@ -19,6 +19,7 @@ package com.ness.flink.config.channel.kafka;
 import com.ness.flink.config.channel.EventTimeExtractor;
 import com.ness.flink.config.channel.KeyExtractor;
 import com.ness.flink.config.operator.DefaultSink;
+import com.ness.flink.config.properties.AwsProperties;
 import com.ness.flink.config.properties.KafkaProducerProperties;
 import lombok.experimental.SuperBuilder;
 import org.apache.flink.api.connector.sink2.Sink;
@@ -37,12 +38,13 @@ import java.util.Properties;
 @SuperBuilder
 public abstract class KafkaAwareSink<S extends Serializable> extends DefaultSink<S> {
     protected final KafkaProducerProperties kafkaProducerProperties;
+    protected final AwsProperties awsProperties;
     protected final Class<S> domainClass;
     protected final KeyExtractor<S> keyExtractor;
     protected final EventTimeExtractor<S> eventTimeExtractor;
 
     protected Properties producerProps() {
-        return kafkaProducerProperties.getProducerProperties();
+        return kafkaProducerProperties.getProducerProperties(awsProperties);
     }
 
     protected String getTopic() {

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaAwareSource.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaAwareSource.java
@@ -17,6 +17,7 @@
 package com.ness.flink.config.channel.kafka;
 
 import com.ness.flink.config.operator.WatermarkAwareSource;
+import com.ness.flink.config.properties.AwsProperties;
 import com.ness.flink.config.properties.KafkaConsumerProperties;
 import lombok.experimental.SuperBuilder;
 import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
@@ -38,6 +39,7 @@ import java.util.Optional;
 @SuperBuilder
 abstract class KafkaAwareSource<S> extends WatermarkAwareSource<S> {
     protected final KafkaConsumerProperties kafkaConsumerProperties;
+    protected final AwsProperties awsProperties;
 
     @Override
     public Optional<Integer> getParallelism() {
@@ -58,7 +60,7 @@ abstract class KafkaAwareSource<S> extends WatermarkAwareSource<S> {
     @Override
     public final SingleOutputStreamOperator<S> build(StreamExecutionEnvironment streamExecutionEnvironment) {
         KafkaSource<S> source = KafkaSource.<S>builder()
-                .setProperties(kafkaConsumerProperties.getConsumerProperties())
+                .setProperties(kafkaConsumerProperties.getConsumerProperties(awsProperties))
                 .setTopics(kafkaConsumerProperties.getTopic())
                 .setStartingOffsets(kafkaConsumerProperties.getOffsetsInitializer())
                 .setDeserializer(WithMetricsKafkaDeserialization.build(getName(), getDeserializationSchema(),

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaSinkFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaSinkFactory.java
@@ -20,6 +20,7 @@ import com.ness.flink.config.channel.EventTimeExtractor;
 import com.ness.flink.config.channel.KeyExtractor;
 import com.ness.flink.config.channel.SinkFactory;
 import com.ness.flink.config.operator.DefaultSink;
+import com.ness.flink.config.properties.AwsProperties;
 import com.ness.flink.config.properties.KafkaProducerProperties;
 import java.io.Serializable;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -35,12 +36,17 @@ public abstract class KafkaSinkFactory implements SinkFactory {
             .name(sinkName)
             .eventTimeExtractor(eventTimeExtractor)
             .keyExtractor(keyExtractor)
+            .awsProperties(buildAwsProperties(parameterTool))
             .kafkaProducerProperties(buildKafkaProducerProperties(sinkName, parameterTool))
             .build();
     }
 
     protected KafkaProducerProperties buildKafkaProducerProperties(String sinkName, ParameterTool parameterTool) {
         return KafkaProducerProperties.from(sinkName, parameterTool);
+    }
+
+    protected static AwsProperties buildAwsProperties(ParameterTool parameterTool) {
+        return AwsProperties.from(parameterTool);
     }
 
 }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaSourceFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaSourceFactory.java
@@ -18,6 +18,7 @@ package com.ness.flink.config.channel.kafka;
 
 import com.ness.flink.config.channel.SourceFactory;
 import com.ness.flink.config.operator.DefaultSource;
+import com.ness.flink.config.properties.AwsProperties;
 import com.ness.flink.config.properties.KafkaConsumerProperties;
 import com.ness.flink.config.properties.WatermarkProperties;
 import com.ness.flink.schema.PojoDeserializationSchema;
@@ -37,6 +38,7 @@ public abstract class KafkaSourceFactory implements SourceFactory {
             .watermarkProperties(watermarkProperties)
             .timestampAssignerFunction(timestampAssignerFunction)
             .valueSchema(new PojoDeserializationSchema<>(domainClass))
+            .awsProperties(buildAwsProperties(parameterTool))
             .kafkaConsumerProperties(buildKafkaConsumerProperties(sourceName, parameterTool))
             .build();
 
@@ -44,5 +46,9 @@ public abstract class KafkaSourceFactory implements SourceFactory {
 
     protected static KafkaConsumerProperties buildKafkaConsumerProperties(String sourceName, ParameterTool parameterTool) {
         return KafkaConsumerProperties.from(sourceName, parameterTool);
+    }
+
+    protected static AwsProperties buildAwsProperties(ParameterTool parameterTool) {
+        return AwsProperties.from(parameterTool);
     }
 }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/confluent/ConfluentAvroSpecificRecordSink.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/confluent/ConfluentAvroSpecificRecordSink.java
@@ -48,6 +48,6 @@ public final class ConfluentAvroSpecificRecordSink<S extends SpecificRecordBase>
     private RegistryAvroSerializationSchema<S> buildSerializationSchema() {
         return ConfluentRegistryAvroSerializationSchema.forSpecific(domainClass, getTopic() + "-value",
                 kafkaProducerProperties.getConfluentSchemaRegistry(),
-                kafkaProducerProperties.getConfluentRegistryConfigs());
+                kafkaProducerProperties.getConfluentRegistryConfigs(awsProperties));
     }
 }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/confluent/ConfluentSinkFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/confluent/ConfluentSinkFactory.java
@@ -34,6 +34,7 @@ public class ConfluentSinkFactory extends KafkaSinkFactory {
             .eventTimeExtractor(eventTimeExtractor)
             .keyExtractor(keyExtractor)
             .kafkaProducerProperties(buildKafkaProducerProperties(sinkName, parameterTool))
+            .awsProperties(buildAwsProperties(parameterTool))
             .build();
     }
 }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/confluent/ConfluentSourceFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/confluent/ConfluentSourceFactory.java
@@ -37,9 +37,10 @@ public class ConfluentSourceFactory extends KafkaSourceFactory {
             .name(sourceName)
             .watermarkProperties(watermarkProperties)
             .timestampAssignerFunction(timestampAssignerFunction)
+            .awsProperties(buildAwsProperties(parameterTool))
             .valueSchema(ConfluentRegistryAvroDeserializationSchema
                 .forSpecific(domainClass, kafkaConsumerProperties.getConfluentSchemaRegistry(),
-                    kafkaConsumerProperties.getConfluentRegistryConfigs()))
+                    kafkaConsumerProperties.getConfluentRegistryConfigs(buildAwsProperties(parameterTool))))
             .kafkaConsumerProperties(kafkaConsumerProperties)
             .build();
     }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/msk/MskAvroSpecificRecordSink.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/msk/MskAvroSpecificRecordSink.java
@@ -19,7 +19,6 @@ package com.ness.flink.config.channel.kafka.msk;
 import com.amazonaws.services.schemaregistry.flink.avro.GlueSchemaRegistryAvroSerializationSchema;
 import com.ness.flink.config.channel.kafka.KafkaAwareSink;
 import com.ness.flink.config.channel.kafka.KafkaSerializationSchemaBuilder;
-import com.ness.flink.config.properties.AwsProperties;
 import lombok.experimental.SuperBuilder;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
@@ -30,8 +29,6 @@ import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
  */
 @SuperBuilder
 public final class MskAvroSpecificRecordSink<S extends SpecificRecordBase> extends KafkaAwareSink<S> {
-    private final AwsProperties awsProperties;
-
     @Override
     protected KafkaRecordSerializationSchema<S> getKafkaRecordSerializationSchema() {
         return KafkaSerializationSchemaBuilder.<S>builder()

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/msk/MskSinkFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/msk/MskSinkFactory.java
@@ -20,7 +20,6 @@ import com.ness.flink.config.channel.EventTimeExtractor;
 import com.ness.flink.config.channel.KeyExtractor;
 import com.ness.flink.config.channel.kafka.KafkaSinkFactory;
 import com.ness.flink.config.operator.DefaultSink;
-import com.ness.flink.config.properties.AwsProperties;
 import com.ness.flink.config.properties.KafkaProducerProperties;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -31,13 +30,12 @@ public class MskSinkFactory extends KafkaSinkFactory {
     @Override
     public <S extends SpecificRecordBase> DefaultSink<S> sinkAvroSpecific(String sinkName, Class<S> domainClass,
         ParameterTool parameterTool, KeyExtractor<S> keyExtractor, @Nullable EventTimeExtractor<S> eventTimeExtractor) {
-        var awsProperties = AwsProperties.from(parameterTool);
         return MskAvroSpecificRecordSink.<S>builder()
             .domainClass(domainClass)
             .name(sinkName)
             .keyExtractor(keyExtractor)
             .eventTimeExtractor(eventTimeExtractor)
-            .awsProperties(awsProperties)
+            .awsProperties(buildAwsProperties(parameterTool))
             .kafkaProducerProperties(KafkaProducerProperties.from(sinkName, parameterTool))
             .build();
     }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/msk/MskSourceFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/msk/MskSourceFactory.java
@@ -40,6 +40,7 @@ public class MskSourceFactory extends KafkaSourceFactory {
             .name(sourceName)
             .watermarkProperties(watermarkProperties)
             .timestampAssignerFunction(timestampAssignerFunction)
+            .awsProperties(buildAwsProperties(parameterTool))
             .valueSchema(GlueSchemaRegistryAvroDeserializationSchema.forSpecific(domainClass,
                 awsProperties.getAwsGlueSchemaConfig(kafkaConsumerProperties.getTopic())))
             .kafkaConsumerProperties(kafkaConsumerProperties)

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/AwsProperties.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/AwsProperties.java
@@ -37,6 +37,7 @@ import java.util.Map;
 public class AwsProperties implements RawProperties<AwsProperties> {
     private static final long serialVersionUID = -5869618107831628207L;
     private static final String AWS_PROPERTY_NAME = "aws";
+    public static final String AWS_REGION = "region";
     private static final String AWS_PROPERTY_SECOND_NAME = "glue.";
 
     /**

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/KafkaProperties.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/KafkaProperties.java
@@ -16,17 +16,23 @@
 
 package com.ness.flink.config.properties;
 
+import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.CLIENT_NAMESPACE;
+import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.USER_INFO_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.ness.flink.security.Credentials;
+import com.ness.flink.security.SecretsProviderFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.CLIENT_NAMESPACE;
 
 /**
  * Common Kafka properties
@@ -46,6 +52,13 @@ public abstract class KafkaProperties {
     @ToString.Exclude
     protected Map<String, String> rawValues = new LinkedHashMap<>();
     private static final String CONFLUENT_SCHEMA_REGISTRY_KEY = "schema.registry.url";
+    private static final String SECRET_PROVIDER_KEY = "secretProvider";
+    @VisibleForTesting
+    static final String SECRET_NAME = ".secret.name";
+
+    private static final CharSequence KAFKA_USERNAME_TEMPLATE = "{API_USERNAME}";
+    private static final CharSequence KAFKA_PASSWORD_TEMPLATE = "{API_PASSWORD}";
+    private static final CharSequence MASKED_VALUE = "***";
 
     /**
      * Provides Confluent Schema Registry URL
@@ -59,18 +72,80 @@ public abstract class KafkaProperties {
 
     /**
      * Provides Confluent Schema related properties
+     * @param secretProviderProperties properties required for SecretProvider initialization
      * @return Confluent Schema related properties
      */
-    public Map<String, String> getConfluentRegistryConfigs() {
-        return getSchemaRegistryProperties().entrySet().stream().filter(Objects::nonNull)
-                .map(p -> {
-                    if (p.getKey().startsWith(CLIENT_NAMESPACE)) {
-                        String newKey = p.getKey().substring(CLIENT_NAMESPACE.length());
-                        return Map.entry(newKey, p.getValue());
-                    } else {
-                        return Map.entry(p.getKey(), p.getValue());
-                    }
-                }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    public Map<String, String> getConfluentRegistryConfigs(@Nullable RawProperties<?> secretProviderProperties) {
+        Map<String, String> schemaData = getSchemaRegistryProperties().entrySet().stream().filter(Objects::nonNull)
+            .map(p -> {
+                if (p.getKey().startsWith(CLIENT_NAMESPACE)) {
+                    String newKey = p.getKey().substring(CLIENT_NAMESPACE.length());
+                    return Map.entry(newKey, p.getValue());
+                } else {
+                    return Map.entry(p.getKey(), p.getValue());
+                }
+            }).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        Credentials credentials = getCredentials("schema", secretProviderProperties);
+        if (credentials != null) {
+            // Replace with secrets from SM
+            schemaData.put(USER_INFO_CONFIG, credentials.getUsername() + ":" + credentials.getPassword());
+        }
+        return schemaData;
+    }
+
+    /**
+     * Retrieve secrets from SM
+     * @param prefix prefix of secret, could be "schema" or "bootstrap" etc
+     * @param secretProviderProperties secret provider settings
+     * @return Credentials if they required
+     */
+    protected @Nullable Credentials getCredentials(String prefix, @Nullable RawProperties<?> secretProviderProperties) {
+        String secretName = rawValues.get(prefix + SECRET_NAME);
+        if (secretName != null) {
+            var errorMsg = String.format("Secret name provided %s", secretName);
+            // we got secret name from user
+            String secretProviderStr = rawValues.get(SECRET_PROVIDER_KEY);
+            if (secretProviderStr == null) {
+                throw new IllegalArgumentException(errorMsg + " but secret provider is empty");
+            }
+            if (secretProviderProperties == null) {
+                throw new IllegalArgumentException(errorMsg + " but secret provider properties are empty");
+            }
+            Credentials credentials = SecretsProviderFactory.retrieve(SecretProvider.valueOf(secretProviderStr), secretProviderProperties, secretName);
+            if (credentials == null) {
+                throw new IllegalArgumentException(errorMsg + " but credentials are empty. Please check infrastructure configuration");
+            }
+            return credentials;
+        }
+        return null;
+    }
+
+    /**
+     * If necessary replaces Kafka settings with credentials which could be taken from SM
+     * @param kafkaProperties kafka properties
+     * @param secretProviderProperties secret provider settings
+     * @return masked sasl.jaas.config configuration if replacement had a place
+     */
+    protected String replaceKafkaCredentials(Map<String, String> kafkaProperties,
+        @Nullable RawProperties<?> secretProviderProperties) {
+        Credentials credentials = getCredentials("bootstrap", secretProviderProperties);
+        String masked = null;
+        if (credentials != null) {
+            String jaasConfig = kafkaProperties.get(SASL_JAAS_CONFIG);
+            if (jaasConfig != null) {
+                // Masks credentials
+                masked = jaasConfig.replace(KAFKA_USERNAME_TEMPLATE, MASKED_VALUE);
+                masked = masked.replace(KAFKA_PASSWORD_TEMPLATE, MASKED_VALUE);
+                // Build with credentials
+                jaasConfig = jaasConfig.replace(KAFKA_USERNAME_TEMPLATE, credentials.getUsername());
+                jaasConfig = jaasConfig.replace(KAFKA_PASSWORD_TEMPLATE, credentials.getPassword());
+                kafkaProperties.put(SASL_JAAS_CONFIG, jaasConfig);
+            } else {
+                throw new IllegalArgumentException(
+                    "Provided secret but " + SASL_JAAS_CONFIG + " configuration is empty");
+            }
+        }
+        return masked;
     }
 
     private Map<String, String> getSchemaRegistryProperties() {

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/SecretProvider.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/SecretProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.config.properties;
+
+/**
+ * Different Secret providers
+ */
+public enum SecretProvider {
+    AWS
+}

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/security/Credentials.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/security/Credentials.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.security;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author Khokhlov Pavel
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Credentials implements Serializable {
+
+    private static final long serialVersionUID = 4363674946524404122L;
+    private String username;
+    private String password;
+}

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/security/SecretsAware.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/security/SecretsAware.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.security;
+
+/**
+ * @author Khokhlov Pavel
+ */
+@FunctionalInterface
+public interface SecretsAware {
+    Credentials retrieve(String secretName);
+}

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/security/SecretsProviderFactory.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/security/SecretsProviderFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.security;
+
+import com.ness.flink.config.aws.SecretsRetrieval;
+import com.ness.flink.config.properties.RawProperties;
+import com.ness.flink.config.properties.SecretProvider;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+/**
+ * @author Khokhlov Pavel
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecretsProviderFactory {
+
+    private static SecretsAware provider;
+
+    public static synchronized Credentials retrieve(@NonNull SecretProvider secretProvider,
+        RawProperties<?> secretProviderProperties, String secretName) {
+        if (provider == null) {
+            if (SecretProvider.AWS == secretProvider) {
+                provider = SecretsRetrieval.build(secretProviderProperties);
+            } else {
+                throw new UnsupportedOperationException("Not supported secret provider: " + secretProvider);
+            }
+        }
+        return provider.retrieve(secretName);
+    }
+}

--- a/flink-baseline/flink-common/src/test/java/com/ness/flink/config/properties/KafkaConsumerPropertiesTest.java
+++ b/flink-baseline/flink-common/src/test/java/com/ness/flink/config/properties/KafkaConsumerPropertiesTest.java
@@ -16,7 +16,16 @@
 
 package com.ness.flink.config.properties;
 
+import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE;
+import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.USER_INFO_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
+import static org.mockito.ArgumentMatchers.eq;
+
 import com.ness.flink.config.properties.KafkaConsumerProperties.Offsets;
+import com.ness.flink.security.Credentials;
+import com.ness.flink.security.SecretsProviderFactory;
+import java.util.Map;
+import java.util.Properties;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
@@ -26,12 +35,8 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-import java.util.Properties;
-
-import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE;
-import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.USER_INFO_CONFIG;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 
 /**
@@ -41,36 +46,59 @@ class KafkaConsumerPropertiesTest {
 
     @Test
     void shouldGetDefaultValues() {
-        KafkaConsumerProperties properties = KafkaConsumerProperties.from("defaultSource", ParameterTool.fromMap(Map.of()));
-        Assertions.assertNull(properties.getParallelism());
-        Assertions.assertEquals("defaultSource", properties.getName());
-        Assertions.assertEquals("http://localhost:8085", properties.getConfluentSchemaRegistry());
-        Map<String, String> confluentRegistryConfigs = properties.getConfluentRegistryConfigs();
-        Assertions.assertEquals(3, confluentRegistryConfigs.size());
-        Assertions.assertEquals("URL", confluentRegistryConfigs.get(BASIC_AUTH_CREDENTIALS_SOURCE));
-        Assertions.assertEquals("user:pwd", confluentRegistryConfigs.get(USER_INFO_CONFIG));
+        var schemaCredentials = new Credentials("userFromSecret", "passwordFromSecret");
+        var kafkaCredentials = new Credentials("kafkaUserFromSecret", "kafkaPasswordFromSecret");
 
-        Assertions.assertEquals(Offsets.COMMITTED, properties.getOffsets());
-        OffsetsInitializer offsetsInitializer = properties.getOffsetsInitializer();
-        Assertions.assertEquals(OffsetResetStrategy.EARLIEST, offsetsInitializer.getAutoOffsetResetStrategy());
+        try (MockedStatic<SecretsProviderFactory> utilities = Mockito.mockStatic(SecretsProviderFactory.class)) {
 
-        Assertions.assertNull(properties.getTimestamp());
-        Assertions.assertNull(properties.getTopic());
+            utilities.when(() -> SecretsProviderFactory
+                .retrieve(Mockito.any(), Mockito.any(), eq("schemaRegistrySecret"))).thenReturn(schemaCredentials);
 
-        Properties consumerProperties = properties.getConsumerProperties();
-        Assertions.assertEquals("localhost:29092", consumerProperties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
-        Assertions.assertEquals("flinkProcessor", consumerProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG));
-        Assertions.assertEquals("1", consumerProperties.getProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG));
-        Assertions.assertEquals("500", consumerProperties.getProperty(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG));
-        Assertions.assertEquals("read_committed", consumerProperties.getProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG));
-        Assertions.assertEquals("true", consumerProperties.getProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG));
-        Assertions.assertEquals("5000", consumerProperties.getProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG));
-        Assertions.assertEquals("defaultSource", consumerProperties.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key()));
+            utilities.when(() -> SecretsProviderFactory
+                .retrieve(Mockito.any(), Mockito.any(), eq("kafkaSecret"))).thenReturn(kafkaCredentials);
+
+
+            KafkaConsumerProperties properties = KafkaConsumerProperties.from("defaultSource",
+                ParameterTool.fromMap(Map.of()));
+            AwsProperties awsProperties = AwsProperties.from(ParameterTool.fromMap(Map.of()));
+            Assertions.assertNull(properties.getParallelism());
+            Assertions.assertEquals("defaultSource", properties.getName());
+            Assertions.assertEquals("http://localhost:8085", properties.getConfluentSchemaRegistry());
+            Map<String, String> confluentRegistryConfigs = properties.getConfluentRegistryConfigs(awsProperties);
+            Assertions.assertEquals(3, confluentRegistryConfigs.size());
+            Assertions.assertEquals("URL", confluentRegistryConfigs.get(BASIC_AUTH_CREDENTIALS_SOURCE));
+            Assertions.assertEquals("userFromSecret:passwordFromSecret",
+                confluentRegistryConfigs.get(USER_INFO_CONFIG));
+
+            Assertions.assertEquals(Offsets.COMMITTED, properties.getOffsets());
+            OffsetsInitializer offsetsInitializer = properties.getOffsetsInitializer();
+            Assertions.assertEquals(OffsetResetStrategy.EARLIEST, offsetsInitializer.getAutoOffsetResetStrategy());
+
+            Assertions.assertNull(properties.getTimestamp());
+            Assertions.assertNull(properties.getTopic());
+
+            Properties consumerProperties = properties.getConsumerProperties(awsProperties);
+            Assertions.assertEquals("localhost:29092",
+                consumerProperties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            Assertions.assertEquals("flinkProcessor", consumerProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG));
+            Assertions.assertEquals("1", consumerProperties.getProperty(ConsumerConfig.FETCH_MIN_BYTES_CONFIG));
+            Assertions.assertEquals("500", consumerProperties.getProperty(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG));
+            Assertions.assertEquals("read_committed",
+                consumerProperties.getProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG));
+            Assertions.assertEquals("true", consumerProperties.getProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG));
+            Assertions.assertEquals("5000",
+                consumerProperties.getProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG));
+            Assertions.assertEquals("defaultSource",
+                consumerProperties.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key()));
+            Assertions.assertEquals("org.apache.kafka.common.security.plain.PlainLoginModule   required username='kafkaUserFromSecret' password='kafkaPasswordFromSecret';", consumerProperties.getProperty(SASL_JAAS_CONFIG));
+        }
     }
 
     @Test
     void shouldGetValues() {
-        KafkaConsumerProperties properties = KafkaConsumerProperties.from("test.source", ParameterTool.fromMap(Map.of()), "/application-test.yml");
+        KafkaConsumerProperties properties = KafkaConsumerProperties.from("test.source",
+            ParameterTool.fromMap(Map.of()), "/application-test.yml");
+        AwsProperties awsProperties = AwsProperties.from(ParameterTool.fromMap(Map.of()));
         Assertions.assertEquals(4, properties.getParallelism());
         Assertions.assertEquals(8, properties.getMaxParallelism());
         Assertions.assertEquals("test.source", properties.getName());
@@ -81,19 +109,22 @@ class KafkaConsumerPropertiesTest {
         Assertions.assertEquals(Offsets.TIMESTAMP, properties.getOffsets());
         Assertions.assertEquals(OffsetResetStrategy.NONE, offsetsInitializer.getAutoOffsetResetStrategy());
 
-        Properties consumerProperties = properties.getConsumerProperties();
-        Assertions.assertEquals("localhost:9092", consumerProperties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        Properties consumerProperties = properties.getConsumerProperties(null);
+        Assertions.assertEquals("localhost:9092",
+            consumerProperties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
         Assertions.assertEquals("test.source", consumerProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG));
-        Assertions.assertEquals("test.source", consumerProperties.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key()));
+        Assertions.assertEquals("test.source",
+            consumerProperties.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key()));
         Assertions.assertEquals("PLAIN", consumerProperties.getProperty(SaslConfigs.SASL_MECHANISM));
-        Assertions.assertEquals("SASL_SSL", consumerProperties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+        Assertions.assertEquals("SASL_SSL",
+            consumerProperties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
 
         String expectedSaslJaasConfig = "org.apache.kafka.common.security.plain.PlainLoginModule required username='USER1' password='PASSWD1';";
         Assertions.assertEquals(expectedSaslJaasConfig, properties.getRawValues().get(SaslConfigs.SASL_JAAS_CONFIG));
         Assertions.assertEquals(expectedSaslJaasConfig, consumerProperties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
 
         Assertions.assertEquals("http://localhost:8085", properties.getConfluentSchemaRegistry());
-        Map<String, String> confluentRegistryConfigs = properties.getConfluentRegistryConfigs();
+        Map<String, String> confluentRegistryConfigs = properties.getConfluentRegistryConfigs(awsProperties);
         Assertions.assertEquals(3, confluentRegistryConfigs.size());
         Assertions.assertEquals("USER_INFO", confluentRegistryConfigs.get(BASIC_AUTH_CREDENTIALS_SOURCE));
         Assertions.assertEquals("12121:233232", confluentRegistryConfigs.get(USER_INFO_CONFIG));

--- a/flink-baseline/flink-common/src/test/java/com/ness/flink/config/properties/KafkaProducerPropertiesTest.java
+++ b/flink-baseline/flink-common/src/test/java/com/ness/flink/config/properties/KafkaProducerPropertiesTest.java
@@ -16,18 +16,24 @@
 
 package com.ness.flink.config.properties;
 
+import com.ness.flink.security.Credentials;
+import com.ness.flink.security.SecretsProviderFactory;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 import java.util.Properties;
 
 import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE;
 import static io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig.USER_INFO_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
+import static org.mockito.ArgumentMatchers.eq;
 
 
 /**
@@ -37,26 +43,41 @@ class KafkaProducerPropertiesTest {
 
     @Test
     void shouldGetDefaultValues() {
-        KafkaProducerProperties properties = KafkaProducerProperties.from("defaultSource", ParameterTool.fromMap(Map.of()));
-        Assertions.assertNull(properties.getParallelism());
-        Assertions.assertNull(properties.getTopic());
 
-        Assertions.assertNotNull(properties.getDeliveryGuarantee());
-        Assertions.assertEquals(DeliveryGuarantee.AT_LEAST_ONCE, properties.getDeliveryGuarantee());
-        Assertions.assertNull(properties.getTransactionIdPrefix());
+        var schemaCredentials = new Credentials("userFromSecret", "passwordFromSecret");
+        var kafkaCredentials = new Credentials("kafkaUsernameFromSecret", "kafkaPasswordFromSecret");
 
-        Assertions.assertEquals("http://localhost:8085", properties.getConfluentSchemaRegistry());
-        Map<String, String> confluentRegistryConfigs = properties.getConfluentRegistryConfigs();
-        Assertions.assertEquals(3, confluentRegistryConfigs.size());
-        Assertions.assertEquals("URL", confluentRegistryConfigs.get(BASIC_AUTH_CREDENTIALS_SOURCE));
-        Assertions.assertEquals("user:pwd", confluentRegistryConfigs.get(USER_INFO_CONFIG));
+        try (MockedStatic<SecretsProviderFactory> utilities = Mockito.mockStatic(SecretsProviderFactory.class)) {
 
-        Properties producerProperties = properties.getProducerProperties();
-        Assertions.assertEquals("localhost:29092", producerProperties.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            utilities.when(() -> SecretsProviderFactory
+                .retrieve(Mockito.any(), Mockito.any(), eq("schemaRegistrySecret"))).thenReturn(schemaCredentials);
 
-        Assertions.assertEquals("all", producerProperties.getProperty(ProducerConfig.ACKS_CONFIG));
-        Assertions.assertEquals("16384", producerProperties.getProperty(ProducerConfig.BATCH_SIZE_CONFIG));
-        Assertions.assertEquals("0", producerProperties.getProperty(ProducerConfig.LINGER_MS_CONFIG));
+            utilities.when(() -> SecretsProviderFactory
+                .retrieve(Mockito.any(), Mockito.any(), eq("kafkaSecret"))).thenReturn(kafkaCredentials);
+
+            KafkaProducerProperties properties = KafkaProducerProperties.from("defaultSource", ParameterTool.fromMap(Map.of()));
+            AwsProperties awsProperties = AwsProperties.from(ParameterTool.fromMap(Map.of()));
+            Assertions.assertNull(properties.getParallelism());
+            Assertions.assertNull(properties.getTopic());
+
+            Assertions.assertNotNull(properties.getDeliveryGuarantee());
+            Assertions.assertEquals(DeliveryGuarantee.AT_LEAST_ONCE, properties.getDeliveryGuarantee());
+            Assertions.assertNull(properties.getTransactionIdPrefix());
+
+            Assertions.assertEquals("http://localhost:8085", properties.getConfluentSchemaRegistry());
+            Map<String, String> confluentRegistryConfigs = properties.getConfluentRegistryConfigs(awsProperties);
+            Assertions.assertEquals(3, confluentRegistryConfigs.size());
+            Assertions.assertEquals("URL", confluentRegistryConfigs.get(BASIC_AUTH_CREDENTIALS_SOURCE));
+            Assertions.assertEquals("userFromSecret:passwordFromSecret", confluentRegistryConfigs.get(USER_INFO_CONFIG));
+
+            Properties producerProperties = properties.getProducerProperties(awsProperties);
+            Assertions.assertEquals("localhost:29092", producerProperties.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            Assertions.assertEquals("org.apache.kafka.common.security.plain.PlainLoginModule   required username='kafkaUsernameFromSecret' password='kafkaPasswordFromSecret';", producerProperties.getProperty(SASL_JAAS_CONFIG));
+
+            Assertions.assertEquals("all", producerProperties.getProperty(ProducerConfig.ACKS_CONFIG));
+            Assertions.assertEquals("16384", producerProperties.getProperty(ProducerConfig.BATCH_SIZE_CONFIG));
+            Assertions.assertEquals("0", producerProperties.getProperty(ProducerConfig.LINGER_MS_CONFIG));
+        }
     }
 
     @Test
@@ -72,7 +93,7 @@ class KafkaProducerPropertiesTest {
         Assertions.assertEquals("test.sink", properties.getName());
         Assertions.assertEquals("test-out", properties.getTopic());
 
-        Properties producerProperties = properties.getProducerProperties();
+        Properties producerProperties = properties.getProducerProperties(null);
 
         Assertions.assertEquals("localhost:29092", producerProperties.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
     }
@@ -81,7 +102,7 @@ class KafkaProducerPropertiesTest {
     @SetEnvironmentVariable(key = "KAFKA_PRODUCER_BOOTSTRAP_SERVERS", value = "kafka:9090")
     void shouldOverwriteFromArgsAndEnv() {
         KafkaProducerProperties properties = buildTest();
-        Properties producerProperties = properties.getProducerProperties();
+        Properties producerProperties = properties.getProducerProperties(null);
         Assertions.assertEquals("kafka:9090", producerProperties.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
     }
 
@@ -90,12 +111,24 @@ class KafkaProducerPropertiesTest {
     void shouldNotOverwriteFromArgs() {
         KafkaProducerProperties  properties = KafkaProducerProperties.from("test.sink", ParameterTool.fromMap(
                 Map.of("kafka.producer.bootstrap.servers", "kafka:9095")), "/application-test.yml");
-        Properties producerProperties = properties.getProducerProperties();
+        Properties producerProperties = properties.getProducerProperties(null);
         Assertions.assertEquals("kafka:9095", producerProperties.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG), "Argument has higher priority than ENV property");
     }
 
     private KafkaProducerProperties buildTest() {
         return KafkaProducerProperties.from("test.sink", ParameterTool.fromMap(Map.of()), "/application-test.yml");
+    }
+
+    @Test
+    void testGettingCredentials() {
+        KafkaProducerProperties properties = KafkaProducerProperties.from("defaultSource", ParameterTool.fromMap(Map.of()));
+        AwsProperties awsProperties = AwsProperties.from(ParameterTool.fromMap(Map.of()));
+        var credentials = properties.getCredentials("unknown", awsProperties);
+        Assertions.assertNull(credentials, "Unregistered prefix provided, we can't get credentials");
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+            properties.getCredentials("bootstrap", null),
+            "Secret name provided bootstrap but secret provider is empty");
     }
 
 }

--- a/flink-baseline/flink-common/src/test/java/com/ness/flink/security/SecretsProviderFactoryIT.java
+++ b/flink-baseline/flink-common/src/test/java/com/ness/flink/security/SecretsProviderFactoryIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.security;
+
+import com.ness.flink.config.properties.AwsProperties;
+import com.ness.flink.config.properties.SecretProvider;
+import java.util.Map;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SecretsProviderFactoryIT {
+    @Test
+    void shouldRetrieveSecret() {
+        var awsProperties = AwsProperties.from(ParameterTool.fromMap(Map.of()));
+        Credentials credentials = SecretsProviderFactory.retrieve(SecretProvider.AWS, awsProperties, "test");
+
+        Assertions.assertNotNull(credentials);
+        Assertions.assertEquals("login1", credentials.getUsername());
+        Assertions.assertEquals("password1", credentials.getPassword());
+    }
+}

--- a/flink-baseline/flink-common/src/test/resources/application.yml
+++ b/flink-baseline/flink-common/src/test/resources/application.yml
@@ -21,14 +21,20 @@ watermark:
   windowSizeMs: 10000
 
 kafka:
+  # We are using AWS Secret Manager
+  secretProvider: AWS
   bootstrap.servers: localhost:29092
   schema.registry.url: http://localhost:8085
   schema.registry.basic.auth.credentials.source: URL
-  #schema.registry.basic.auth.credentials.source: USER_INFO
+  # Providing Secret name
+  schema.secret.name: schemaRegistrySecret
+  # Since Secret provided, should be replaced with real user and password
   schema.registry.basic.auth.user.info: user:pwd
-  #security.protocol: SASL_SSL
-  #sasl.mechanism: PLAIN
-  #sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule   required username='API_KEY' password='API_PASSWD';"
+  # Kafka secret.name
+  bootstrap.secret.name: kafkaSecret
+  security.protocol: SASL_SSL
+  sasl.mechanism: PLAIN
+  sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule   required username='{API_USERNAME}' password='{API_PASSWORD}';"
 
 aws:
   region: us-east-1

--- a/flink-baseline/flink-example/pom.xml
+++ b/flink-baseline/flink-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-jdbc-sink/pom.xml
+++ b/flink-baseline/flink-jdbc-sink/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-snapshot/pom.xml
+++ b/flink-baseline/flink-snapshot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -43,6 +43,7 @@
         <dropwizard.metrics.version>4.1.10.1</dropwizard.metrics.version>
         <aws-kinesisanalytics-runtime.version>1.2.0</aws-kinesisanalytics-runtime.version>
         <aws.glue.flink.serde.version>1.1.14</aws.glue.flink.serde.version>
+        <aws.secret.manager.version>1.0.2</aws.secret.manager.version>
     </properties>
 
     <dependencyManagement>
@@ -133,6 +134,12 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws.secretsmanager</groupId>
+                <artifactId>aws-secretsmanager-caching-java</artifactId>
+                <version>${aws.secret.manager.version}</version>
             </dependency>
 
             <dependency>
@@ -275,6 +282,11 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-flink-serde</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws.secretsmanager</groupId>
+            <artifactId>aws-secretsmanager-caching-java</artifactId>
         </dependency>
 
         <dependency>

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/flink-domain/pom.xml
+++ b/flink-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-example-domain/pom.xml
+++ b/flink-example-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-test-example/pom.xml
+++ b/flink-test-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.10-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.2.0</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -93,6 +99,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.ness.flink.generic</groupId>
     <artifactId>flink-generic</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.11-SNAPSHOT</version>
 
     <modules>
         <module>flink-domain</module>


### PR DESCRIPTION
- Introduced secrets configuration
- Fixed issue with printing out security sensitive information, it will be masked
- Supports Confluent Cloud & AWS MSK cases