### PR TITLE
RFAC-143: Check if Source Parallelism is equal to Kafka Topic Partitions

### DIFF
--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaAwareSource.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/channel/kafka/KafkaAwareSource.java
@@ -19,6 +19,7 @@ package com.ness.flink.config.channel.kafka;
 import com.ness.flink.config.operator.WatermarkAwareSource;
 import com.ness.flink.config.properties.AwsProperties;
 import com.ness.flink.config.properties.KafkaConsumerProperties;
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -40,6 +41,8 @@ import java.util.Optional;
 abstract class KafkaAwareSource<S> extends WatermarkAwareSource<S> {
     protected final KafkaConsumerProperties kafkaConsumerProperties;
     protected final AwsProperties awsProperties;
+    @Override
+    public Optional<String> getTopic() { return Optional.ofNullable(kafkaConsumerProperties.getTopic()); }
 
     @Override
     public Optional<Integer> getParallelism() {

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/operator/DefaultSource.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/operator/DefaultSource.java
@@ -53,4 +53,10 @@ public abstract class DefaultSource<S> implements OperatorDefinition {
      */
     public abstract Optional<Integer> getMaxParallelism();
 
+    /**
+     * The Topic name of the Source
+     * This is the topic that the source reads its data from
+     * @return topic name of the source
+     */
+    public abstract Optional<String> getTopic();
 }

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/KafkaAdminProperties.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/config/properties/KafkaAdminProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.config.properties;
+
+import static com.ness.flink.config.properties.OperatorPropertiesFactory.DEFAULT_CONFIG_FILE;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+
+@Slf4j
+@Getter
+@Setter
+@ToString
+public class KafkaAdminProperties extends KafkaProperties implements RawProperties<KafkaAdminProperties> {
+    private static final long serialVersionUID = 8374164378532623386L;
+    private static final String SHARED_PROPERTY_NAME = "kafka.admin";
+
+    public static KafkaAdminProperties from(@NonNull String name, @NonNull ParameterTool parameterTool) {
+        return from(name, parameterTool, DEFAULT_CONFIG_FILE);
+    }
+
+    @VisibleForTesting
+    static KafkaAdminProperties from(@NonNull String name, @NonNull ParameterTool parameterTool,
+        @NonNull String ymlConfigFile) {
+        SharedKafkaProperties sharedProperties = SharedKafkaProperties.from(name, parameterTool, ymlConfigFile);
+        KafkaAdminProperties adminProperties = OperatorPropertiesFactory
+            .from(name, SHARED_PROPERTY_NAME, parameterTool, KafkaAdminProperties.class, ymlConfigFile);
+        // Original Kafka Admin properties
+        final Map<String, String> adminRawValues = new LinkedHashMap<>(adminProperties.rawValues);
+        // Provide all default Kafka properties
+        adminProperties.rawValues.putAll(sharedProperties.getRawValues());
+        // Now overwrites with Admin related
+        adminProperties.rawValues.putAll(adminRawValues);
+        log.info("Building Kafka Admin: adminProperties={}", adminProperties);
+        return adminProperties;
+    }
+
+    public Properties getAdminProperties() {
+        Properties adminProperties = new Properties();
+        Map<String, String> filtered = filterNonAdminProperties();
+        // We should provide unique prefix (in our case it's Operator name) for building "client.id"
+        filtered.putIfAbsent(KafkaSourceOptions.CLIENT_ID_PREFIX.key(), getName());
+        adminProperties.putAll(filtered);
+        log.info("Building Kafka AdminProperties: properties={}", adminProperties);
+        return adminProperties;
+    }
+
+    private Map<String, String> filterNonAdminProperties() {
+        return rawValues.entrySet().stream()
+            .filter(e -> AdminClientConfig.configNames().contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+}

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/stream/StreamOperation.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/stream/StreamOperation.java
@@ -24,11 +24,13 @@ import com.ness.flink.config.operator.DefaultSource;
 import com.ness.flink.config.operator.SinkDefinition;
 import com.ness.flink.config.properties.ChannelProperties;
 import com.ness.flink.config.properties.KafkaAdminProperties;
+import com.ness.flink.config.properties.KafkaConsumerProperties;
 import com.ness.flink.config.properties.WatermarkProperties;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -117,6 +119,7 @@ public class StreamOperation {
      */
     private <S> SingleOutputStreamOperator<S> configureSource(DefaultSource<S> defaultSource) {
         SingleOutputStreamOperator<S> streamSource = defaultSource.build(streamBuilder.getEnv());
+
         String name = defaultSource.getName();
         streamSource.name(name).uid(name);
         final int parallelism = defaultSource.getParallelism().orElse(streamBuilder.getParallelism());
@@ -131,8 +134,8 @@ public class StreamOperation {
 
 
         KafkaAdminProperties kafkaAdminProperties = KafkaAdminProperties.from(defaultSource.getName(), streamBuilder.getParameterTool());
-
-        checkParallelismPartitionMatch(kafkaAdminProperties, streamSource.getParallelism(), "ycInputsLive");
+        defaultSource.getTopic().ifPresent(topic ->
+            checkParallelismPartitionMatch(kafkaAdminProperties, streamSource.getParallelism(), topic));
 
         return streamSource;
     }

--- a/flink-baseline/flink-common/src/test/java/com/ness/flink/stream/StreamBuilderTest.java
+++ b/flink-baseline/flink-common/src/test/java/com/ness/flink/stream/StreamBuilderTest.java
@@ -56,6 +56,11 @@ class StreamBuilderTest {
             public Optional<Integer> getMaxParallelism() {
                 return Optional.empty();
             }
+
+            @Override
+            public Optional<String> getTopic() {
+                return Optional.empty();
+            }
         };
 
         StreamBuilder.from(env, params)

--- a/flink-baseline/flink-common/src/test/java/com/ness/flink/stream/StreamOperationTest.java
+++ b/flink-baseline/flink-common/src/test/java/com/ness/flink/stream/StreamOperationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021-2023 Ness Digital Engineering
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ness.flink.stream;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import java.util.Collections;
+
+/**
+ * @author Hu Jeffrey
+ */
+@Slf4j
+class StreamOperationTest {
+
+    @Test
+    void greaterParallelismPartition(){
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
+        ParameterTool params = ParameterTool.fromMap(Collections.emptyMap());
+
+        int parallelism = 5;
+        int partitions = 4;
+        String topic = "testCase1";
+
+        StreamOperation streamOperation = StreamBuilder.from(env, params)
+            .stream();
+
+        Assertions.assertEquals("Your source parallelism (5) is greater than the number of partitions in testCase1 (4)", streamOperation.printParallelismPartitionWarnings(parallelism, partitions, topic));
+
+    }
+
+    @Test
+    void lesserParallelismPartition(){
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
+        ParameterTool params = ParameterTool.fromMap(Collections.emptyMap());
+
+        int parallelism = 3;
+        int partitions = 4;
+        String topic = "testCase2";
+
+        StreamOperation streamOperation = StreamBuilder.from(env, params)
+            .stream();
+
+        Assertions.assertEquals("Your source parallelism (3) is less than the number of partitions in testCase2 (4)", streamOperation.printParallelismPartitionWarnings(parallelism, partitions, topic));
+
+    }
+}

--- a/flink-baseline/flink-example/src/main/resources/application.yml
+++ b/flink-baseline/flink-example/src/main/resources/application.yml
@@ -65,12 +65,12 @@ kafka.producer:
 option.price.source:
   topic: optionsPricesLive
   # Should be equals to kafka partitions number
-  maxParallelism: 4
+  maxParallelism: 3
 
 interest.rates.source:
   topic: ycInputsLive
   # Should be equals to kafka partitions number
-  maxParallelism: 4
+  maxParallelism: 5
 
 configuration.source:
     topic: configuration


### PR DESCRIPTION
- added method to create AdminClient
- added method to get partitions of a topic using AdminClient
- added method to print warnings if the parallelism of the source being configured is not equal to the partitions of the topic the source is connecting to
- create unit test called StreamOperationsTest