### PR TITLE
Flink upgrade to 1.15.4

### DIFF
--- a/flink-baseline/flink-common/pom.xml
+++ b/flink-baseline/flink-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-example/pom.xml
+++ b/flink-baseline/flink-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-jdbc-sink/pom.xml
+++ b/flink-baseline/flink-jdbc-sink/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-snapshot/pom.xml
+++ b/flink-baseline/flink-snapshot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
@@ -36,7 +36,7 @@
     <artifactId>flink-baseline</artifactId>
 
     <properties>
-        <flink.version>1.15.3</flink.version>
+        <flink.version>1.15.4</flink.version>
         <redis.lettuce.version>5.3.7.RELEASE</redis.lettuce.version>
         <embedded.redis.version>0.7.2</embedded.redis.version>
         <log4j.version>2.19.0</log4j.version>

--- a/flink-domain/pom.xml
+++ b/flink-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-example-domain/pom.xml
+++ b/flink-example-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-test-example/pom.xml
+++ b/flink-test-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.11-SNAPSHOT</version>
+        <version>2.0.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.ness.flink.generic</groupId>
     <artifactId>flink-generic</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.12-SNAPSHOT</version>
 
     <modules>
         <module>flink-domain</module>


### PR DESCRIPTION
- Upgraded to Flink-1.15.4 (https://flink.apache.org/2023/03/15/apache-flink-1.15.4-release-announcement/)