### PR TITLE
Added  aarch64 (apple m1/m2 arch) support

### DIFF
--- a/flink-baseline/flink-common/pom.xml
+++ b/flink-baseline/flink-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-example/docker/docker-compose.yml
+++ b/flink-baseline/flink-example/docker/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       KAFKA_ADVERTISED_LISTENERS: ignored
 
   mysql:
-    image: mysql:5.7.41
+    image: mysql:8.0.33
     container_name: mysql
     command: --default-authentication-plugin=mysql_native_password
     restart: always

--- a/flink-baseline/flink-example/pom.xml
+++ b/flink-baseline/flink-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-example/pom.xml
+++ b/flink-baseline/flink-example/pom.xml
@@ -34,7 +34,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>it.ozimov</groupId>
+            <groupId>com.github.kstyrc</groupId>
             <artifactId>embedded-redis</artifactId>
         </dependency>
         <dependency>

--- a/flink-baseline/flink-jdbc-sink/pom.xml
+++ b/flink-baseline/flink-jdbc-sink/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-snapshot/pom.xml
+++ b/flink-baseline/flink-snapshot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -89,6 +89,12 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>com.github.kstyrc</groupId>
+                <artifactId>embedded-redis</artifactId>
+                <version>0.6</version>
+                <scope>test</scope>
+            </dependency>
 
             <!-- These dependencies are excluded from the application JAR by default. -->
             <dependency>

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/flink-domain/pom.xml
+++ b/flink-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-example-domain/pom.xml
+++ b/flink-example-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-test-example/pom.xml
+++ b/flink-test-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.13-SNAPSHOT</version>
+        <version>2.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.ness.flink.generic</groupId>
     <artifactId>flink-generic</artifactId>
-    <version>2.0.13-SNAPSHOT</version>
+    <version>2.0.14-SNAPSHOT</version>
 
     <modules>
         <module>flink-domain</module>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>3.1.0</version>
                     <!-- without this config fails on local machine -->
                     <configuration>
                         <forkCount>3</forkCount>


### PR DESCRIPTION
- Updated maven-surefire-plugin to support ARM M1
- Updated embedded-redis
  - Rosetta installation still required (softwareupdate --install-rosetta)
- Updated mysql image (ARM compatible)
- Bump version to 2.0.14-SNAPSHOT