### PR TITLE
Upgrade to Apache Flink 1.18.1 version

### DIFF
--- a/flink-baseline/flink-common/pom.xml
+++ b/flink-baseline/flink-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-common/src/main/java/com/ness/flink/stream/StreamBuilder.java
+++ b/flink-baseline/flink-common/src/main/java/com/ness/flink/stream/StreamBuilder.java
@@ -46,6 +46,7 @@ public class StreamBuilder {
         return from(ParameterTool.fromArgs(args));
     }
 
+    @SuppressWarnings("PMD.CloseResource")
     public static StreamBuilder from(ParameterTool parameterTool) {
         StreamExecutionEnvironment env = EnvironmentFactory.from(parameterTool);
         return from(env, parameterTool);

--- a/flink-baseline/flink-common/src/test/java/com/ness/flink/config/properties/KafkaConsumerPropertiesTest.java
+++ b/flink-baseline/flink-common/src/test/java/com/ness/flink/config/properties/KafkaConsumerPropertiesTest.java
@@ -107,7 +107,7 @@ class KafkaConsumerPropertiesTest {
         Assertions.assertEquals(123, properties.getTimestamp());
         OffsetsInitializer offsetsInitializer = properties.getOffsetsInitializer();
         Assertions.assertEquals(Offsets.TIMESTAMP, properties.getOffsets());
-        Assertions.assertEquals(OffsetResetStrategy.NONE, offsetsInitializer.getAutoOffsetResetStrategy());
+        Assertions.assertEquals(OffsetResetStrategy.LATEST, offsetsInitializer.getAutoOffsetResetStrategy());
 
         Properties consumerProperties = properties.buildProperties(null);
         Assertions.assertEquals("localhost:9092",

--- a/flink-baseline/flink-example/README.md
+++ b/flink-baseline/flink-example/README.md
@@ -29,6 +29,7 @@ https://ness-nde.atlassian.net/wiki/spaces/RSH/pages/3498115669/Example+of+Flink
     1. You have to specify as a `Main class:` in Run Configuration `com.ness.flink.example.pipeline.SmoothingPricesJob`.
     2. Then check setting: `Include dependencies with "Provided" scope`
     3. Specify parameters: `-localDev true -localParallelism 4` in `Program arguments:` field.
+    4. Specify JVM parameters: `--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED` in `VM Options` field.
  6. You could use [Grafana](http://localhost:3000) to monitor your app
  7. You could also explore [Prometheus](http://localhost:9090) metrics 
 

--- a/flink-baseline/flink-example/pom.xml
+++ b/flink-baseline/flink-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-jdbc-sink/pom.xml
+++ b/flink-baseline/flink-jdbc-sink/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/flink-snapshot/pom.xml
+++ b/flink-baseline/flink-snapshot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-baseline</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-baseline/pom.xml
+++ b/flink-baseline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
@@ -36,7 +36,9 @@
     <artifactId>flink-baseline</artifactId>
 
     <properties>
-        <flink.version>1.15.4</flink.version>
+        <flink.version>1.18.1</flink.version>
+        <flink.connector.kafka>3.0.1-1.18</flink.connector.kafka>
+        <jackson.version>2.15.3</jackson.version>
         <redis.lettuce.version>5.3.7.RELEASE</redis.lettuce.version>
         <log4j.version>2.19.0</log4j.version>
         <dropwizard.metrics.version>4.1.10.1</dropwizard.metrics.version>
@@ -67,6 +69,12 @@
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
                 <scope>runtime</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>
@@ -137,7 +145,7 @@
             <dependency>
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-connector-kafka</artifactId>
-                <version>${flink.version}</version>
+                <version>${flink.connector.kafka}</version>
             </dependency>
 
             <dependency>
@@ -300,6 +308,12 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/flink-domain/pom.xml
+++ b/flink-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-example-domain/pom.xml
+++ b/flink-example-domain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-test-example/pom.xml
+++ b/flink-test-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flink-generic</artifactId>
         <groupId>com.ness.flink.generic</groupId>
-        <version>2.0.17-SNAPSHOT</version>
+        <version>2.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.ness.flink.generic</groupId>
     <artifactId>flink-generic</artifactId>
-    <version>2.0.17-SNAPSHOT</version>
+    <version>2.0.18-SNAPSHOT</version>
 
     <modules>
         <module>flink-domain</module>
@@ -38,7 +38,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <sonar.organization>ness.com</sonar.organization>
@@ -269,12 +269,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.1</version>
                     <!-- without this config fails on local machine -->
                     <configuration>
                         <forkCount>3</forkCount>
                         <reuseForks>true</reuseForks>
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                        <argLine>
+                            -Xmx1024m
+                            --add-opens java.base/java.util=ALL-UNNAMED
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Since AWS KDA now do support Flink 1.18.1 
- Updated Kafka connector for Flink 1.18.1, updated instructions how to run
- Use Java 17
- fixed issued with build
- Added Jackson explicitly to CP